### PR TITLE
Fix: IcseFormTemplate

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -5160,55 +5160,66 @@ SccForm.propTypes = {
  * SecretsManagerForm
  * @param {Object} props
  */
-class SecretsManagerForm extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = this.props.data;
-    this.handleInputChange = this.handleInputChange.bind(this);
-    buildFormDefaultInputMethods(this);
-    buildFormFunctions(this);
-    this.state.use_secrets_manager = true;
+var SecretsManagerForm = /*#__PURE__*/function (_Component) {
+  _inherits(SecretsManagerForm, _Component);
+  var _super = _createSuper(SecretsManagerForm);
+  function SecretsManagerForm(props) {
+    var _this;
+    _classCallCheck(this, SecretsManagerForm);
+    _this = _super.call(this, props);
+    _this.state = _this.props.data;
+    _this.handleInputChange = _this.handleInputChange.bind(_assertThisInitialized(_this));
+    buildFormDefaultInputMethods(_assertThisInitialized(_this));
+    buildFormFunctions(_assertThisInitialized(_this));
+    _this.state.use_secrets_manager = true;
+    return _this;
   }
 
   /**
    * handle input change
    * @param {event} event event
    */
-  handleInputChange(event) {
-    this.setState(this.eventTargetToNameAndValue(event));
-  }
-  render() {
-    return /*#__PURE__*/React__default["default"].createElement(React__default["default"].Fragment, null, /*#__PURE__*/React__default["default"].createElement(IcseFormGroup, null, /*#__PURE__*/React__default["default"].createElement(IcseNameInput, {
-      id: this.state.name + "-name",
-      componentName: "Secrets Manager",
-      component: "secrets_manager",
-      value: this.state.name,
-      onChange: this.handleInputChange,
-      componentProps: this.props,
-      hideHelperText: true,
-      invalid: this.props.invalidCallback(this.state, this.props),
-      invalidText: this.props.invalidTextCallback(this.state, this.props)
-    }), /*#__PURE__*/React__default["default"].createElement(IcseSelect, {
-      formName: "Secrets Manager",
-      value: this.state.resource_group,
-      groups: this.props.resourceGroups,
-      handleInputChange: this.handleInputChange,
-      className: "fieldWidth",
-      name: "resource_group",
-      labelText: "Resource Group"
-    })), /*#__PURE__*/React__default["default"].createElement("div", {
-      className: "fieldWidth"
-    }, /*#__PURE__*/React__default["default"].createElement(IcseSelect, {
-      value: this.state.kms_key_name,
-      groups: this.props.encryptionKeys,
-      formName: "Secrets Manager",
-      name: "kms_key_name",
-      className: "fieldWidth",
-      labelText: "Encryption Key",
-      handleInputChange: this.handleInputChange
-    })));
-  }
-}
+  _createClass(SecretsManagerForm, [{
+    key: "handleInputChange",
+    value: function handleInputChange(event) {
+      this.setState(this.eventTargetToNameAndValue(event));
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      return /*#__PURE__*/React__default["default"].createElement(React__default["default"].Fragment, null, /*#__PURE__*/React__default["default"].createElement(IcseFormGroup, null, /*#__PURE__*/React__default["default"].createElement(IcseNameInput, {
+        id: this.state.name + "-name",
+        componentName: "Secrets Manager",
+        component: "secrets_manager",
+        value: this.state.name,
+        onChange: this.handleInputChange,
+        componentProps: this.props,
+        hideHelperText: true,
+        invalid: this.props.invalidCallback(this.state, this.props),
+        invalidText: this.props.invalidTextCallback(this.state, this.props)
+      }), /*#__PURE__*/React__default["default"].createElement(IcseSelect, {
+        formName: "Secrets Manager",
+        value: this.state.resource_group,
+        groups: this.props.resourceGroups,
+        handleInputChange: this.handleInputChange,
+        className: "fieldWidth",
+        name: "resource_group",
+        labelText: "Resource Group"
+      })), /*#__PURE__*/React__default["default"].createElement("div", {
+        className: "fieldWidth"
+      }, /*#__PURE__*/React__default["default"].createElement(IcseSelect, {
+        value: this.state.kms_key_name,
+        groups: this.props.encryptionKeys,
+        formName: "Secrets Manager",
+        name: "kms_key_name",
+        className: "fieldWidth",
+        labelText: "Encryption Key",
+        handleInputChange: this.handleInputChange
+      })));
+    }
+  }]);
+  return SecretsManagerForm;
+}(React.Component);
 SecretsManagerForm.propTypes = {
   data: PropTypes__default["default"].shape({
     name: PropTypes__default["default"].string,
@@ -7461,7 +7472,7 @@ var ToggleForm = /*#__PURE__*/function (_React$Component) {
               onClick: this.toggleDeleteModal,
               name: this.props.name,
               disabled: this.props.deleteDisabled(this.props),
-              disableDeleteMessage: this.props.disableDeleteMessage(this.props)
+              disableDeleteMessage: this.props.deleteDisabledMessage
             })
           }))
         }, /*#__PURE__*/React__default["default"].createElement(UnsavedChangesModal, {
@@ -7473,9 +7484,7 @@ var ToggleForm = /*#__PURE__*/function (_React$Component) {
           onModalSubmit: this.dismissChangesAndClose,
           useDefaultUnsavedMessage: this.state.useDefaultUnsavedMessage
         }), /*#__PURE__*/React__default["default"].createElement(DeleteModal, {
-          name:
-          // use tab panel name if passed
-          this.props.tabPanel ? this.props.tabPanel.name : this.props.name,
+          name: this.props.name,
           modalOpen: this.state.showDeleteModal,
           onModalClose: this.toggleDeleteModal,
           onModalSubmit: this.onDelete
@@ -7666,9 +7675,11 @@ var IcseFormTemplate = /*#__PURE__*/function (_React$Component) {
           name: this.props.name,
           showIfEmpty: this.props.arrayData
         }), this.props.arrayData.map(function (data, index) {
-          var _this2$props, _this2$props2;
+          var _this2$props, _this2$props2, _this2$props3, _this2$props4;
           // return a form with the index and props
           return /*#__PURE__*/React__default["default"].createElement(ToggleForm, _extends({}, _this2.props.toggleFormProps, {
+            propsMatchState: _this2.props.propsMatchState,
+            disableSave: _this2.props.disableSave,
             name: data[_this2.props.toggleFormFieldName],
             tabPanel: {
               name: _this2.props.name,
@@ -7691,7 +7702,9 @@ var IcseFormTemplate = /*#__PURE__*/function (_React$Component) {
             show: _this2.shouldShow(index),
             shownChildren: _this2.state.shownChildForms,
             onSave: (_this2$props = _this2.props) === null || _this2$props === void 0 ? void 0 : _this2$props.onSave,
-            onDelete: (_this2$props2 = _this2.props) === null || _this2$props2 === void 0 ? void 0 : _this2$props2.onDelete
+            onDelete: (_this2$props2 = _this2.props) === null || _this2$props2 === void 0 ? void 0 : _this2$props2.onDelete,
+            deleteDisabled: (_this2$props3 = _this2.props) === null || _this2$props3 === void 0 ? void 0 : _this2$props3.deleteDisabled,
+            deleteDisabledMessage: (_this2$props4 = _this2.props) === null || _this2$props4 === void 0 ? void 0 : _this2$props4.deleteDisabledMessage
           }));
         }), /*#__PURE__*/React__default["default"].createElement(FormModal, {
           name: this.props.addText,
@@ -7702,6 +7715,7 @@ var IcseFormTemplate = /*#__PURE__*/function (_React$Component) {
         },
         // render the form inside the modal
         RenderForm(this.props.innerForm, _objectSpread2(_objectSpread2({}, this.props.innerFormProps), {}, {
+          disableSave: this.props.disableSave,
           arrayParentName: this.props.arrayParentName,
           isModal: true,
           shouldDisableSubmit: function shouldDisableSubmit() {
@@ -7756,15 +7770,12 @@ IcseFormTemplate.propTypes = {
   // used only for cos keys
   arrayParentName: PropTypes__default["default"].string,
   isMiddleForm: PropTypes__default["default"].bool.isRequired,
-  innerFormProps: PropTypes__default["default"].shape({
-    disableSave: PropTypes__default["default"].func.isRequired
-  }).isRequired,
-  toggleFormProps: PropTypes__default["default"].shape({
-    disableSave: PropTypes__default["default"].func.isRequired,
-    propsMatchState: PropTypes__default["default"].func.isRequired
-  }).isRequired,
+  innerFormProps: PropTypes__default["default"].object.isRequired,
+  toggleFormProps: PropTypes__default["default"].object.isRequired,
   toggleFormFieldName: PropTypes__default["default"].string.isRequired,
-  hideAbout: PropTypes__default["default"].bool
+  hideAbout: PropTypes__default["default"].bool,
+  deleteDisabled: PropTypes__default["default"].func.isRequired,
+  deleteDisabledMessage: PropTypes__default["default"].string.isRequired
 };
 
 exports.AppIdForm = AppIdForm;

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -5149,55 +5149,66 @@ SccForm.propTypes = {
  * SecretsManagerForm
  * @param {Object} props
  */
-class SecretsManagerForm extends Component {
-  constructor(props) {
-    super(props);
-    this.state = this.props.data;
-    this.handleInputChange = this.handleInputChange.bind(this);
-    buildFormDefaultInputMethods(this);
-    buildFormFunctions(this);
-    this.state.use_secrets_manager = true;
+var SecretsManagerForm = /*#__PURE__*/function (_Component) {
+  _inherits(SecretsManagerForm, _Component);
+  var _super = _createSuper(SecretsManagerForm);
+  function SecretsManagerForm(props) {
+    var _this;
+    _classCallCheck(this, SecretsManagerForm);
+    _this = _super.call(this, props);
+    _this.state = _this.props.data;
+    _this.handleInputChange = _this.handleInputChange.bind(_assertThisInitialized(_this));
+    buildFormDefaultInputMethods(_assertThisInitialized(_this));
+    buildFormFunctions(_assertThisInitialized(_this));
+    _this.state.use_secrets_manager = true;
+    return _this;
   }
 
   /**
    * handle input change
    * @param {event} event event
    */
-  handleInputChange(event) {
-    this.setState(this.eventTargetToNameAndValue(event));
-  }
-  render() {
-    return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(IcseFormGroup, null, /*#__PURE__*/React.createElement(IcseNameInput, {
-      id: this.state.name + "-name",
-      componentName: "Secrets Manager",
-      component: "secrets_manager",
-      value: this.state.name,
-      onChange: this.handleInputChange,
-      componentProps: this.props,
-      hideHelperText: true,
-      invalid: this.props.invalidCallback(this.state, this.props),
-      invalidText: this.props.invalidTextCallback(this.state, this.props)
-    }), /*#__PURE__*/React.createElement(IcseSelect, {
-      formName: "Secrets Manager",
-      value: this.state.resource_group,
-      groups: this.props.resourceGroups,
-      handleInputChange: this.handleInputChange,
-      className: "fieldWidth",
-      name: "resource_group",
-      labelText: "Resource Group"
-    })), /*#__PURE__*/React.createElement("div", {
-      className: "fieldWidth"
-    }, /*#__PURE__*/React.createElement(IcseSelect, {
-      value: this.state.kms_key_name,
-      groups: this.props.encryptionKeys,
-      formName: "Secrets Manager",
-      name: "kms_key_name",
-      className: "fieldWidth",
-      labelText: "Encryption Key",
-      handleInputChange: this.handleInputChange
-    })));
-  }
-}
+  _createClass(SecretsManagerForm, [{
+    key: "handleInputChange",
+    value: function handleInputChange(event) {
+      this.setState(this.eventTargetToNameAndValue(event));
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(IcseFormGroup, null, /*#__PURE__*/React.createElement(IcseNameInput, {
+        id: this.state.name + "-name",
+        componentName: "Secrets Manager",
+        component: "secrets_manager",
+        value: this.state.name,
+        onChange: this.handleInputChange,
+        componentProps: this.props,
+        hideHelperText: true,
+        invalid: this.props.invalidCallback(this.state, this.props),
+        invalidText: this.props.invalidTextCallback(this.state, this.props)
+      }), /*#__PURE__*/React.createElement(IcseSelect, {
+        formName: "Secrets Manager",
+        value: this.state.resource_group,
+        groups: this.props.resourceGroups,
+        handleInputChange: this.handleInputChange,
+        className: "fieldWidth",
+        name: "resource_group",
+        labelText: "Resource Group"
+      })), /*#__PURE__*/React.createElement("div", {
+        className: "fieldWidth"
+      }, /*#__PURE__*/React.createElement(IcseSelect, {
+        value: this.state.kms_key_name,
+        groups: this.props.encryptionKeys,
+        formName: "Secrets Manager",
+        name: "kms_key_name",
+        className: "fieldWidth",
+        labelText: "Encryption Key",
+        handleInputChange: this.handleInputChange
+      })));
+    }
+  }]);
+  return SecretsManagerForm;
+}(Component);
 SecretsManagerForm.propTypes = {
   data: PropTypes.shape({
     name: PropTypes.string,
@@ -7450,7 +7461,7 @@ var ToggleForm = /*#__PURE__*/function (_React$Component) {
               onClick: this.toggleDeleteModal,
               name: this.props.name,
               disabled: this.props.deleteDisabled(this.props),
-              disableDeleteMessage: this.props.disableDeleteMessage(this.props)
+              disableDeleteMessage: this.props.deleteDisabledMessage
             })
           }))
         }, /*#__PURE__*/React.createElement(UnsavedChangesModal, {
@@ -7462,9 +7473,7 @@ var ToggleForm = /*#__PURE__*/function (_React$Component) {
           onModalSubmit: this.dismissChangesAndClose,
           useDefaultUnsavedMessage: this.state.useDefaultUnsavedMessage
         }), /*#__PURE__*/React.createElement(DeleteModal, {
-          name:
-          // use tab panel name if passed
-          this.props.tabPanel ? this.props.tabPanel.name : this.props.name,
+          name: this.props.name,
           modalOpen: this.state.showDeleteModal,
           onModalClose: this.toggleDeleteModal,
           onModalSubmit: this.onDelete
@@ -7655,9 +7664,11 @@ var IcseFormTemplate = /*#__PURE__*/function (_React$Component) {
           name: this.props.name,
           showIfEmpty: this.props.arrayData
         }), this.props.arrayData.map(function (data, index) {
-          var _this2$props, _this2$props2;
+          var _this2$props, _this2$props2, _this2$props3, _this2$props4;
           // return a form with the index and props
           return /*#__PURE__*/React.createElement(ToggleForm, _extends({}, _this2.props.toggleFormProps, {
+            propsMatchState: _this2.props.propsMatchState,
+            disableSave: _this2.props.disableSave,
             name: data[_this2.props.toggleFormFieldName],
             tabPanel: {
               name: _this2.props.name,
@@ -7680,7 +7691,9 @@ var IcseFormTemplate = /*#__PURE__*/function (_React$Component) {
             show: _this2.shouldShow(index),
             shownChildren: _this2.state.shownChildForms,
             onSave: (_this2$props = _this2.props) === null || _this2$props === void 0 ? void 0 : _this2$props.onSave,
-            onDelete: (_this2$props2 = _this2.props) === null || _this2$props2 === void 0 ? void 0 : _this2$props2.onDelete
+            onDelete: (_this2$props2 = _this2.props) === null || _this2$props2 === void 0 ? void 0 : _this2$props2.onDelete,
+            deleteDisabled: (_this2$props3 = _this2.props) === null || _this2$props3 === void 0 ? void 0 : _this2$props3.deleteDisabled,
+            deleteDisabledMessage: (_this2$props4 = _this2.props) === null || _this2$props4 === void 0 ? void 0 : _this2$props4.deleteDisabledMessage
           }));
         }), /*#__PURE__*/React.createElement(FormModal, {
           name: this.props.addText,
@@ -7691,6 +7704,7 @@ var IcseFormTemplate = /*#__PURE__*/function (_React$Component) {
         },
         // render the form inside the modal
         RenderForm(this.props.innerForm, _objectSpread2(_objectSpread2({}, this.props.innerFormProps), {}, {
+          disableSave: this.props.disableSave,
           arrayParentName: this.props.arrayParentName,
           isModal: true,
           shouldDisableSubmit: function shouldDisableSubmit() {
@@ -7745,15 +7759,12 @@ IcseFormTemplate.propTypes = {
   // used only for cos keys
   arrayParentName: PropTypes.string,
   isMiddleForm: PropTypes.bool.isRequired,
-  innerFormProps: PropTypes.shape({
-    disableSave: PropTypes.func.isRequired
-  }).isRequired,
-  toggleFormProps: PropTypes.shape({
-    disableSave: PropTypes.func.isRequired,
-    propsMatchState: PropTypes.func.isRequired
-  }).isRequired,
+  innerFormProps: PropTypes.object.isRequired,
+  toggleFormProps: PropTypes.object.isRequired,
   toggleFormFieldName: PropTypes.string.isRequired,
-  hideAbout: PropTypes.bool
+  hideAbout: PropTypes.bool,
+  deleteDisabled: PropTypes.func.isRequired,
+  deleteDisabledMessage: PropTypes.string.isRequired
 };
 
 export { AppIdForm, AppIdKeyForm, AtrackerForm, ClusterForm, DeleteButton, DeleteModal, Docs, DynamicRender, DynamicToolTipWrapper, EditCloseIcon, EmptyResourceTile, EncryptionKeyForm, EntitlementSelect, F5VsiForm, F5VsiTemplateForm, FetchSelect, FormModal, IamAccountSettingsForm, IcseFormGroup, IcseFormTemplate, IcseHeading, IcseModal, IcseMultiSelect, IcseNameInput, IcseNumberSelect, IcseSelect, IcseSubForm, IcseTextInput, IcseToggle, IcseToolTip, KeyManagementForm, NetworkAclForm, NetworkingRuleForm, NetworkingRulesOrderCard, ObjectStorageBucketForm, ObjectStorageInstancesForm as ObjectStorageForm, ObjectStorageKeyForm, PopoverWrapper, RenderForm, ResourceGroupForm, SaveAddButton, SaveIcon, SccForm, SecretsManagerForm, SecurityGroupForm, SecurityGroupMultiSelect, SshKeyForm, SshKeyMultiSelect, StatefulTabPanel, StatelessToggleForm, SubnetForm, SubnetMultiSelect, SubnetTierForm, SubnetTileForm, TeleportClaimToRoleForm, TitleGroup, ToggleForm, ToolTipWrapper, TransitGatewayForm, UnderConstruction, UnsavedChangesModal, UpDownButtons, VpcNetworkForm as VpcForm, VpcListMultiSelect, VpeForm, VpnGatewayForm, VsiForm, WorkerPoolForm, buildFormDefaultInputMethods, buildFormFunctions };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "icse-react-assets",
   "homepage": "http://pages.github.ibm.com/icse/icse-react-assets",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "source": "src/index.js",

--- a/src/components/IcseFormTemplate.js
+++ b/src/components/IcseFormTemplate.js
@@ -116,6 +116,8 @@ class IcseFormTemplate extends React.Component {
                 return (
                   <ToggleForm
                     {...this.props.toggleFormProps}
+                    propsMatchState={this.props.propsMatchState}
+                    disableSave={this.props.disableSave}
                     name={data[this.props.toggleFormFieldName]}
                     tabPanel={{
                       name: this.props.name,
@@ -140,6 +142,8 @@ class IcseFormTemplate extends React.Component {
                     shownChildren={this.state.shownChildForms}
                     onSave={this.props?.onSave}
                     onDelete={this.props?.onDelete}
+                    deleteDisabled={this.props?.deleteDisabled}
+                    deleteDisabledMessage={this.props?.deleteDisabledMessage}
                   />
                 );
               })}
@@ -154,6 +158,7 @@ class IcseFormTemplate extends React.Component {
                   // render the form inside the modal
                   RenderForm(this.props.innerForm, {
                     ...this.props.innerFormProps,
+                    disableSave: this.props.disableSave,
                     arrayParentName: this.props.arrayParentName,
                     isModal: true,
                     shouldDisableSubmit: function () {
@@ -214,14 +219,12 @@ IcseFormTemplate.propTypes = {
   tooltip: PropTypes.object, // used only for cos keys
   arrayParentName: PropTypes.string,
   isMiddleForm: PropTypes.bool.isRequired,
-  innerFormProps: PropTypes.shape({ disableSave: PropTypes.func.isRequired })
-    .isRequired,
-  toggleFormProps: PropTypes.shape({
-    disableSave: PropTypes.func.isRequired,
-    propsMatchState: PropTypes.func.isRequired,
-  }).isRequired,
+  innerFormProps: PropTypes.object.isRequired,
+  toggleFormProps: PropTypes.object.isRequired,
   toggleFormFieldName: PropTypes.string.isRequired,
   hideAbout: PropTypes.bool,
+  deleteDisabled: PropTypes.func.isRequired,
+  deleteDisabledMessage: PropTypes.string.isRequired,
 };
 
 export default IcseFormTemplate;

--- a/src/components/ToggleForm.js
+++ b/src/components/ToggleForm.js
@@ -248,9 +248,9 @@ class ToggleForm extends React.Component {
                             onClick={this.toggleDeleteModal}
                             name={this.props.name}
                             disabled={this.props.deleteDisabled(this.props)}
-                            disableDeleteMessage={this.props.disableDeleteMessage(
-                              this.props
-                            )}
+                            disableDeleteMessage={
+                              this.props.deleteDisabledMessage
+                            }
                           />
                         }
                       />
@@ -274,12 +274,7 @@ class ToggleForm extends React.Component {
                   />
                   {/* delete resource */}
                   <DeleteModal
-                    name={
-                      // use tab panel name if passed
-                      this.props.tabPanel
-                        ? this.props.tabPanel.name
-                        : this.props.name
-                    }
+                    name={this.props.name}
                     modalOpen={this.state.showDeleteModal}
                     onModalClose={this.toggleDeleteModal}
                     onModalSubmit={this.onDelete}

--- a/storybook/src/stories/DynamicComponents/IcseFormTemplate.stories.js
+++ b/storybook/src/stories/DynamicComponents/IcseFormTemplate.stories.js
@@ -4,46 +4,7 @@ import { IcseFormTemplate, SshKeyForm } from "icse-react-assets";
 export default {
   component: IcseFormTemplate,
   title: "Components/Dynamic Components/IcseFormTemplate",
-  args: {
-    name: "SSH Keys",
-    hideName: true,
-    addText: "Create an SSH Key",
-    subHeading: false,
-    hideFormTitleButton: false,
-    hideAbout: false,
-    arrayData: [
-      {
-        name: "ssh-key",
-        resource_group: "rg1",
-        public_key: "test-key",
-      },
-    ],
-    innerForm: SshKeyForm,
-    innerFormProps: {
-      resourceGroups: ["rg1", "rg2", "rg3"],
-      disableSave: () => {},
-      invalidCallback: () => {
-        return false;
-      },
-      invalidTextCallback: () => {},
-      invalidKeyCallback: () => {
-        return { invalid: false, invalidText: "" };
-      },
-    },
-    toggleFormProps: {
-      propsMatchState: () => {},
-      disableSave: () => {},
-      hideName: true,
-      name: "ssh-key",
-      submissionFieldName: "ssh_keys",
-      disableDeleteMessage: () => {
-        return "";
-      },
-    },
-    onSave: () => {},
-    onDelete: () => {},
-    onSubmit: () => {},
-  },
+  args: {},
   argTypes: {
     name: {
       description:
@@ -102,6 +63,18 @@ export default {
         "A function that defines what occurs when the resource is deleted",
       type: { required: true },
     },
+    deleteDisabled: {
+      description:
+        "A function returns a boolean if the delete button should be disabled",
+      type: { required: false },
+      control: "none",
+    },
+    deleteDisabledMessage: {
+      description:
+        "A function that returns the message that should be displayed on a disabled delete button",
+      type: { required: false },
+      control: "none",
+    },
     docs: {
       description:
         "A function that returns a docs component for the About tab, otherwise renders UnderConstruction component",
@@ -149,33 +122,27 @@ export default {
       control: "none",
       table: { defaultValue: { summary: "false" } },
     },
+    propsMatchState: {
+      description:
+        "A function that returns a single boolean describing whether the form props and the form's state match",
+      type: { required: true },
+      control: "none",
+    },
+    disableSave: {
+      description:
+        "A function that returns a single boolean describing whether the save button should be disabled",
+      type: { required: true },
+      control: "none",
+    },
     innerFormProps: {
       description:
         "An object containing props to be passed to the form being rendered. Must contain disableSave and any callback functions the form requires.",
       control: "none",
       type: { required: true },
     },
-    ["innerFormProps.disableSave"]: {
-      description:
-        "A function that returns a single boolean describing whether the save button should be disabled or not",
-      type: { required: true },
-      control: "none",
-    },
     toggleFormProps: {
       description:
         "An object containing props to be passed to the ToggleForm (refer to DynamicComponents/ToggleForm). Must contain disableSave function and propsMatchState function, and any other form props",
-      type: { required: true },
-      control: "none",
-    },
-    ["toggleFormProps.disableSave"]: {
-      description:
-        "A function that returns a single boolean describing whether the save button should be disabled or not",
-      type: { required: true },
-      control: "none",
-    },
-    ["toggleFormProps.propsMatchState"]: {
-      description:
-        "A function that returns a single boolean describing whether the form props and the form's state match",
       type: { required: true },
       control: "none",
     },
@@ -209,8 +176,53 @@ export default {
   ],
 };
 
-const IcseFormTemplateStory = ({ ...args }) => {
-  return <IcseFormTemplate {...args} />;
+const IcseFormTemplateStory = () => {
+  return (
+    <IcseFormTemplate
+      name="SSH Keys"
+      hideName={true}
+      addText="Create an SSH Key"
+      subHeading={false}
+      hideFormTitleButton={false}
+      hideAbout={false}
+      arrayData={[
+        {
+          name: "ssh-key",
+          resource_group: "rg1",
+          public_key: "test-key",
+        },
+      ]}
+      innerForm={SshKeyForm}
+      innerFormProps={{
+        resourceGroups: ["rg1", "rg2", "rg3"],
+        invalidCallback: () => {
+          return false;
+        },
+        invalidTextCallback: () => {},
+        invalidKeyCallback: () => {
+          return { invalid: false, invalidText: "" };
+        },
+      }}
+      toggleFormProps={{
+        hideName: true,
+        name: "ssh-key",
+        submissionFieldName: "ssh_keys",
+      }}
+      onSave={() => {}}
+      onDelete={() => {}}
+      onSubmit={() => {}}
+      disableSave={function (stateData, componentProps) {
+        return false;
+      }}
+      propsMatchState={function (stateData, componentProps) {
+        return false;
+      }}
+      deleteDisabledMessage={"Example delete message"}
+      deleteDisabled={() => {
+        return false;
+      }}
+    />
+  );
 };
 
 export const Default = IcseFormTemplateStory.bind({});

--- a/storybook/src/stories/DynamicComponents/ToggleForm.stories.js
+++ b/storybook/src/stories/DynamicComponents/ToggleForm.stories.js
@@ -82,7 +82,7 @@ export default {
       control: "none",
       table: { defaultValue: { summary: "() => { return false; }" } },
     },
-    disableDeleteMessage: {
+    deleteDisabledMessage: {
       description:
         "A string message that should be shown when hovering over a disabled delete button", // description
       type: { required: false }, // required prop or not


### PR DESCRIPTION
-  fix toggle form storybook not loading
 - add prop deleteDisabled (func) to determine if form can't be deleted
 - added prop deleteDisabledMessage (string) for the message to be displayed
 - fix deletion name in delete modal
 - propsMatchState and disableSave now can be passed to the component and not each object, so only have to be passed once
 - updated version #
 
 @jvallexm @hjweds 