### PR TITLE
f5 form now uses props match state, fix prop warning

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -3266,7 +3266,7 @@ class F5VsiForm extends React.Component {
       labelText: "F5 Instance Zones",
       groups: lazyZ.buildNumberDropdownList(4) // 0-3 Zones
       ,
-      value: this.state.zones,
+      value: this.state.zones.toString(),
       handleInputChange: this.handleInputChange
     }), /*#__PURE__*/React__default["default"].createElement(IcseSelect, {
       formName: "f5_vsi_form",
@@ -3311,7 +3311,7 @@ class F5VsiForm extends React.Component {
         resourceGroups: this.props.resourceGroups,
         encryptionKeys: this.props.encryptionKeys,
         hideSaveCallback: this.props.hideSaveCallback,
-        disableSaveCallback: this.props.disableSaveCallback
+        propsMatchState: this.props.propsMatchState
       });
     }))));
   }
@@ -3322,7 +3322,6 @@ class F5VsiTile extends React__default["default"].Component {
     this.state = this.props.data;
     this.handleInputChange = this.handleInputChange.bind(this);
     this.shouldHideSave = this.shouldHideSave.bind(this);
-    this.shouldDisableSave = this.shouldDisableSave.bind(this);
   }
   handleInputChange(event) {
     let {
@@ -3336,9 +3335,6 @@ class F5VsiTile extends React__default["default"].Component {
   shouldHideSave() {
     return this.props.hideSaveCallback(this.state, this.props);
   }
-  shouldDisableSave() {
-    return this.props.disableSaveCallback(this.state, this.props);
-  }
   render() {
     return /*#__PURE__*/React__default["default"].createElement(react.Tile, {
       className: "fieldWidth"
@@ -3351,7 +3347,7 @@ class F5VsiTile extends React__default["default"].Component {
         show: /*#__PURE__*/React__default["default"].createElement(SaveAddButton, {
           onClick: () => this.props.onSave(this.state),
           noDeleteButton: true,
-          disabled: this.shouldDisableSave()
+          disabled: this.props.propsMatchState("f5_vsi", this.state, this.props)
         })
       })
     }), /*#__PURE__*/React__default["default"].createElement(IcseFormGroup, {
@@ -3424,7 +3420,7 @@ F5VsiForm.propTypes = {
   initVsiCallback: PropTypes__default["default"].func.isRequired,
   saveVsiCallback: PropTypes__default["default"].func.isRequired,
   hideSaveCallback: PropTypes__default["default"].func.isRequired,
-  disableSaveCallback: PropTypes__default["default"].func.isRequired
+  propsMatchState: PropTypes__default["default"].func.isRequired
 };
 
 const {

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -3255,7 +3255,7 @@ class F5VsiForm extends Component {
       labelText: "F5 Instance Zones",
       groups: buildNumberDropdownList(4) // 0-3 Zones
       ,
-      value: this.state.zones,
+      value: this.state.zones.toString(),
       handleInputChange: this.handleInputChange
     }), /*#__PURE__*/React.createElement(IcseSelect, {
       formName: "f5_vsi_form",
@@ -3300,7 +3300,7 @@ class F5VsiForm extends Component {
         resourceGroups: this.props.resourceGroups,
         encryptionKeys: this.props.encryptionKeys,
         hideSaveCallback: this.props.hideSaveCallback,
-        disableSaveCallback: this.props.disableSaveCallback
+        propsMatchState: this.props.propsMatchState
       });
     }))));
   }
@@ -3311,7 +3311,6 @@ class F5VsiTile extends React.Component {
     this.state = this.props.data;
     this.handleInputChange = this.handleInputChange.bind(this);
     this.shouldHideSave = this.shouldHideSave.bind(this);
-    this.shouldDisableSave = this.shouldDisableSave.bind(this);
   }
   handleInputChange(event) {
     let {
@@ -3325,9 +3324,6 @@ class F5VsiTile extends React.Component {
   shouldHideSave() {
     return this.props.hideSaveCallback(this.state, this.props);
   }
-  shouldDisableSave() {
-    return this.props.disableSaveCallback(this.state, this.props);
-  }
   render() {
     return /*#__PURE__*/React.createElement(Tile, {
       className: "fieldWidth"
@@ -3340,7 +3336,7 @@ class F5VsiTile extends React.Component {
         show: /*#__PURE__*/React.createElement(SaveAddButton, {
           onClick: () => this.props.onSave(this.state),
           noDeleteButton: true,
-          disabled: this.shouldDisableSave()
+          disabled: this.props.propsMatchState("f5_vsi", this.state, this.props)
         })
       })
     }), /*#__PURE__*/React.createElement(IcseFormGroup, {
@@ -3413,7 +3409,7 @@ F5VsiForm.propTypes = {
   initVsiCallback: PropTypes.func.isRequired,
   saveVsiCallback: PropTypes.func.isRequired,
   hideSaveCallback: PropTypes.func.isRequired,
-  disableSaveCallback: PropTypes.func.isRequired
+  propsMatchState: PropTypes.func.isRequired
 };
 
 const {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "icse-react-assets",
   "homepage": "http://ibm.github.io/icse-react-assets",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "source": "src/index.js",

--- a/src/components/forms/F5VsiForm.js
+++ b/src/components/forms/F5VsiForm.js
@@ -69,7 +69,7 @@ class F5VsiForm extends Component {
             name="zones"
             labelText="F5 Instance Zones"
             groups={buildNumberDropdownList(4)} // 0-3 Zones
-            value={this.state.zones}
+            value={this.state.zones.toString()}
             handleInputChange={this.handleInputChange}
           />
           <IcseSelect
@@ -129,7 +129,7 @@ class F5VsiForm extends Component {
                       resourceGroups={this.props.resourceGroups}
                       encryptionKeys={this.props.encryptionKeys}
                       hideSaveCallback={this.props.hideSaveCallback}
-                      disableSaveCallback={this.props.disableSaveCallback}
+                      propsMatchState={this.props.propsMatchState}
                     />
                   );
               })}
@@ -149,7 +149,6 @@ class F5VsiTile extends React.Component {
 
     this.handleInputChange = this.handleInputChange.bind(this);
     this.shouldHideSave = this.shouldHideSave.bind(this);
-    this.shouldDisableSave = this.shouldDisableSave.bind(this);
   }
 
   handleInputChange(event) {
@@ -159,10 +158,6 @@ class F5VsiTile extends React.Component {
 
   shouldHideSave() {
     return this.props.hideSaveCallback(this.state, this.props);
-  }
-
-  shouldDisableSave() {
-    return this.props.disableSaveCallback(this.state, this.props);
   }
 
   render() {
@@ -179,7 +174,11 @@ class F5VsiTile extends React.Component {
                 <SaveAddButton
                   onClick={() => this.props.onSave(this.state)}
                   noDeleteButton
-                  disabled={this.shouldDisableSave()}
+                  disabled={this.props.propsMatchState(
+                    "f5_vsi",
+                    this.state,
+                    this.props
+                  )}
                 />
               }
             />
@@ -260,7 +259,7 @@ F5VsiForm.propTypes = {
   initVsiCallback: PropTypes.func.isRequired,
   saveVsiCallback: PropTypes.func.isRequired,
   hideSaveCallback: PropTypes.func.isRequired,
-  disableSaveCallback: PropTypes.func.isRequired,
+  propsMatchState: PropTypes.func.isRequired,
 };
 
 export default F5VsiForm;

--- a/storybook/src/stories/Forms/F5VsiForm.stories.js
+++ b/storybook/src/stories/Forms/F5VsiForm.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { F5VsiForm } from "icse-react-assets";
-import { azsort } from "lazy-z";
+import { azsort, deepEqual } from "lazy-z";
 
 export default {
   component: F5VsiForm,
@@ -102,9 +102,8 @@ export default {
       type: { required: true }, // required prop or not
       control: "none",
     },
-    disableSaveCallback: {
-      description:
-        "Function that determines whether the save button should be disabled",
+    propsMatchState: {
+      description: "Function that determines props match state",
       type: { required: true }, // required prop or not
       control: "none",
     },
@@ -195,8 +194,8 @@ const F5VsiFormStory = () => {
     return false;
   }
 
-  function shouldDisableSave(stateData, componentProps) {
-    return false;
+  function propsMatchState(field, stateData, componentProps) {
+    return deepEqual(stateData, componentProps.data);
   }
 
   return (
@@ -224,7 +223,7 @@ const F5VsiFormStory = () => {
         initVsiCallback={initVsi}
         saveVsiCallback={saveVsi}
         hideSaveCallback={shouldHideSave}
-        disableSaveCallback={shouldDisableSave}
+        propsMatchState={propsMatchState}
       />
     </div>
   );


### PR DESCRIPTION
- tiles now have save disabled when props match state (consistent behavior with slz)
- hoverText was giving warning for being passed a number (with zones), now resolved