### PR TITLE
Craig 280: Tooltip links not clickable

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -347,14 +347,13 @@ function RenderForm$1(form, formProps) {
  * @returns slz tooltip component
  */
 const IcseToolTip = props => {
-  let link = /*#__PURE__*/React__default["default"].createElement(react.Link, {
-    onClick: () => window.open(props.link, "_blank")
-  }, "this link");
   return /*#__PURE__*/React__default["default"].createElement(React__default["default"].Fragment, null, /*#__PURE__*/React__default["default"].createElement(react.Toggletip, {
     align: props.align
   }, /*#__PURE__*/React__default["default"].createElement(react.ToggletipButton, null, /*#__PURE__*/React__default["default"].createElement(iconsReact.Information, {
     className: "tooltipMarginLeft"
-  })), /*#__PURE__*/React__default["default"].createElement(react.ToggletipContent, null, /*#__PURE__*/React__default["default"].createElement("p", null, props.content, props.link && /*#__PURE__*/React__default["default"].createElement(React__default["default"].Fragment, null, " Visit ", link, " for more information. ")))));
+  })), /*#__PURE__*/React__default["default"].createElement(react.ToggletipContent, null, /*#__PURE__*/React__default["default"].createElement("p", null, props.content), props.link && /*#__PURE__*/React__default["default"].createElement(react.ToggletipActions, null, /*#__PURE__*/React__default["default"].createElement(react.Link, {
+    href: props.link
+  }, "More information")))));
 };
 IcseToolTip.defaultProps = {
   content: "",

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -352,7 +352,7 @@ const IcseToolTip = props => {
   }, /*#__PURE__*/React__default["default"].createElement(react.ToggletipButton, null, /*#__PURE__*/React__default["default"].createElement(iconsReact.Information, {
     className: "tooltipMarginLeft"
   })), /*#__PURE__*/React__default["default"].createElement(react.ToggletipContent, null, /*#__PURE__*/React__default["default"].createElement("p", null, props.content), props.link && /*#__PURE__*/React__default["default"].createElement(react.ToggletipActions, null, /*#__PURE__*/React__default["default"].createElement(react.Link, {
-    href: props.link
+    onClick: () => window.open(props.link, "_blank")
   }, "More information")))));
 };
 IcseToolTip.defaultProps = {

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -351,7 +351,7 @@ const IcseToolTip = props => {
     align: props.align
   }, /*#__PURE__*/React__default["default"].createElement(react.ToggletipButton, null, /*#__PURE__*/React__default["default"].createElement(iconsReact.Information, {
     className: "tooltipMarginLeft"
-  })), /*#__PURE__*/React__default["default"].createElement(react.ToggletipContent, null, /*#__PURE__*/React__default["default"].createElement("p", null, props.content), props.link && /*#__PURE__*/React__default["default"].createElement(react.ToggletipActions, null, /*#__PURE__*/React__default["default"].createElement(react.Link, {
+  })), /*#__PURE__*/React__default["default"].createElement(react.ToggletipContent, null, /*#__PURE__*/React__default["default"].createElement("p", null, props.content), props.link && /*#__PURE__*/React__default["default"].createElement(react.ToggletipActions, null, /*#__PURE__*/React__default["default"].createElement("a", {
     onClick: () => window.open(props.link, "_blank")
   }, "More information")))));
 };

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -1,5 +1,5 @@
 import '@carbon/styles/css/styles.css';
-import { Popover, PopoverContent, Toggletip, ToggletipButton, ToggletipContent, Link, Button, StructuredListWrapper, StructuredListHead, StructuredListRow, StructuredListCell, StructuredListBody, Select, SelectItem, Tile, Modal, Tabs, TabList, Tab, TabPanels, TabPanel, Toggle, TextInput, FilterableMultiSelect, TextArea, PasswordInput, NumberInput, Dropdown, Tag } from '@carbon/react';
+import { Popover, PopoverContent, Toggletip, ToggletipButton, ToggletipContent, ToggletipActions, Link, Button, StructuredListWrapper, StructuredListHead, StructuredListRow, StructuredListCell, StructuredListBody, Select, SelectItem, Tile, Modal, Tabs, TabList, Tab, TabPanels, TabPanel, Toggle, TextInput, FilterableMultiSelect, TextArea, PasswordInput, NumberInput, Dropdown, Tag } from '@carbon/react';
 import lazyZ, { kebabCase as kebabCase$2, isEmpty, isNullOrEmptyString as isNullOrEmptyString$4, buildNumberDropdownList, titleCase as titleCase$1, isFunction as isFunction$1, contains as contains$2, snakeCase, isBoolean, prettyJSON, transpose, allFieldsNull, containsKeys, capitalize as capitalize$2, isIpv4CidrOrAddress as isIpv4CidrOrAddress$2, deepEqual, parseIntFromZone, splat as splat$1, distinct, getObjectFromArray, isWholeNumber as isWholeNumber$1, isInRange as isInRange$1, eachKey } from 'lazy-z';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -336,14 +336,13 @@ function RenderForm$1(form, formProps) {
  * @returns slz tooltip component
  */
 const IcseToolTip = props => {
-  let link = /*#__PURE__*/React.createElement(Link, {
-    onClick: () => window.open(props.link, "_blank")
-  }, "this link");
   return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(Toggletip, {
     align: props.align
   }, /*#__PURE__*/React.createElement(ToggletipButton, null, /*#__PURE__*/React.createElement(Information, {
     className: "tooltipMarginLeft"
-  })), /*#__PURE__*/React.createElement(ToggletipContent, null, /*#__PURE__*/React.createElement("p", null, props.content, props.link && /*#__PURE__*/React.createElement(React.Fragment, null, " Visit ", link, " for more information. ")))));
+  })), /*#__PURE__*/React.createElement(ToggletipContent, null, /*#__PURE__*/React.createElement("p", null, props.content), props.link && /*#__PURE__*/React.createElement(ToggletipActions, null, /*#__PURE__*/React.createElement(Link, {
+    href: props.link
+  }, "More information")))));
 };
 IcseToolTip.defaultProps = {
   content: "",

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -341,7 +341,7 @@ const IcseToolTip = props => {
   }, /*#__PURE__*/React.createElement(ToggletipButton, null, /*#__PURE__*/React.createElement(Information, {
     className: "tooltipMarginLeft"
   })), /*#__PURE__*/React.createElement(ToggletipContent, null, /*#__PURE__*/React.createElement("p", null, props.content), props.link && /*#__PURE__*/React.createElement(ToggletipActions, null, /*#__PURE__*/React.createElement(Link, {
-    href: props.link
+    onClick: () => window.open(props.link, "_blank")
   }, "More information")))));
 };
 IcseToolTip.defaultProps = {

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -1,5 +1,5 @@
 import '@carbon/styles/css/styles.css';
-import { Popover, PopoverContent, Toggletip, ToggletipButton, ToggletipContent, ToggletipActions, Link, Button, StructuredListWrapper, StructuredListHead, StructuredListRow, StructuredListCell, StructuredListBody, Select, SelectItem, Tile, Modal, Tabs, TabList, Tab, TabPanels, TabPanel, Toggle, TextInput, FilterableMultiSelect, TextArea, PasswordInput, NumberInput, Dropdown, Tag } from '@carbon/react';
+import { Popover, PopoverContent, Toggletip, ToggletipButton, ToggletipContent, ToggletipActions, Button, StructuredListWrapper, StructuredListHead, StructuredListRow, StructuredListCell, StructuredListBody, Select, SelectItem, Tile, Modal, Tabs, TabList, Tab, TabPanels, TabPanel, Toggle, TextInput, FilterableMultiSelect, TextArea, PasswordInput, NumberInput, Dropdown, Tag } from '@carbon/react';
 import lazyZ, { kebabCase as kebabCase$2, isEmpty, isNullOrEmptyString as isNullOrEmptyString$4, buildNumberDropdownList, titleCase as titleCase$1, isFunction as isFunction$1, contains as contains$2, snakeCase, isBoolean, prettyJSON, transpose, allFieldsNull, containsKeys, capitalize as capitalize$2, isIpv4CidrOrAddress as isIpv4CidrOrAddress$2, deepEqual, parseIntFromZone, splat as splat$1, distinct, getObjectFromArray, isWholeNumber as isWholeNumber$1, isInRange as isInRange$1, eachKey } from 'lazy-z';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -340,7 +340,7 @@ const IcseToolTip = props => {
     align: props.align
   }, /*#__PURE__*/React.createElement(ToggletipButton, null, /*#__PURE__*/React.createElement(Information, {
     className: "tooltipMarginLeft"
-  })), /*#__PURE__*/React.createElement(ToggletipContent, null, /*#__PURE__*/React.createElement("p", null, props.content), props.link && /*#__PURE__*/React.createElement(ToggletipActions, null, /*#__PURE__*/React.createElement(Link, {
+  })), /*#__PURE__*/React.createElement(ToggletipContent, null, /*#__PURE__*/React.createElement("p", null, props.content), props.link && /*#__PURE__*/React.createElement(ToggletipActions, null, /*#__PURE__*/React.createElement("a", {
     onClick: () => window.open(props.link, "_blank")
   }, "More information")))));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "icse-react-assets",
-  "version": "0.6.3",
+  "version": "0.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "icse-react-assets",
-      "version": "0.6.3",
+      "version": "0.6.10",
       "dependencies": {
         "@carbon/icons-react": "^11.18.0",
         "@carbon/react": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "icse-react-assets",
   "homepage": "http://ibm.github.io/icse-react-assets",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "icse-react-assets",
   "homepage": "http://ibm.github.io/icse-react-assets",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "icse-react-assets",
   "homepage": "http://ibm.github.io/icse-react-assets",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "source": "src/index.js",

--- a/src/components/Tooltips.js
+++ b/src/components/Tooltips.js
@@ -2,6 +2,7 @@ import { addClassName } from "../lib";
 import React from "react";
 import {
   Toggletip,
+  ToggletipActions,
   ToggletipButton,
   ToggletipContent,
   Link,
@@ -26,9 +27,6 @@ function RenderForm(form, formProps) {
  * @returns slz tooltip component
  */
 export const IcseToolTip = (props) => {
-  let link = (
-    <Link onClick={() => window.open(props.link, "_blank")}>this link</Link>
-  );
   return (
     <>
       <Toggletip align={props.align}>
@@ -36,10 +34,12 @@ export const IcseToolTip = (props) => {
           <Information className="tooltipMarginLeft" />
         </ToggletipButton>
         <ToggletipContent>
-          <p>
-            {props.content}
-            {props.link && <> Visit {link} for more information. </>}
-          </p>
+          <p>{props.content}</p>
+          {props.link && (
+            <ToggletipActions>
+              <Link href={props.link}>More information</Link>
+            </ToggletipActions>
+          )}
         </ToggletipContent>
       </Toggletip>
     </>

--- a/src/components/Tooltips.js
+++ b/src/components/Tooltips.js
@@ -5,7 +5,6 @@ import {
   ToggletipActions,
   ToggletipButton,
   ToggletipContent,
-  Link,
 } from "@carbon/react";
 import { Information } from "@carbon/icons-react";
 import PropTypes from "prop-types";
@@ -37,9 +36,9 @@ export const IcseToolTip = (props) => {
           <p>{props.content}</p>
           {props.link && (
             <ToggletipActions>
-              <Link onClick={() => window.open(props.link, "_blank")}>
+              <a href={props.link} target="_blank" rel="noopener noreferrer">
                 More information
-              </Link>
+              </a>
             </ToggletipActions>
           )}
         </ToggletipContent>

--- a/src/components/Tooltips.js
+++ b/src/components/Tooltips.js
@@ -37,7 +37,9 @@ export const IcseToolTip = (props) => {
           <p>{props.content}</p>
           {props.link && (
             <ToggletipActions>
-              <Link href={props.link}>More information</Link>
+              <Link onClick={() => window.open(props.link, "_blank")}>
+                More information
+              </Link>
             </ToggletipActions>
           )}
         </ToggletipContent>


### PR DESCRIPTION
no link:
<img width="331" alt="Screenshot 2023-05-22 at 2 46 22 PM" src="https://github.com/IBM/icse-react-assets/assets/25370707/b09a5e56-a981-474f-9213-3bb2f6d60bef">
with link:
<img width="593" alt="Screenshot 2023-05-22 at 2 46 13 PM" src="https://github.com/IBM/icse-react-assets/assets/25370707/82986ed2-aca5-4b2d-b6d9-ad57ee4114d2">

I used carbon's ToggleTipContent with the Link object like they show in their storybooks [here](https://react.carbondesignsystem.com/?path=/docs/components-toggletip--playground).