### PR TITLE
Craig 967: Fix margin bottom

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -2225,7 +2225,6 @@ IcseSubForm.propTypes = {
 };
 const IcseHeading = props => {
   let className = utils_5(props);
-  className = className.replace("marginBottomSmall", "");
   return /*#__PURE__*/React__default["default"].createElement("div", {
     className: className
   }, /*#__PURE__*/React__default["default"].createElement(DynamicToolTipWrapper, {

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -2214,7 +2214,6 @@ IcseSubForm.propTypes = {
 };
 const IcseHeading = props => {
   let className = utils_5(props);
-  className = className.replace("marginBottomSmall", "");
   return /*#__PURE__*/React.createElement("div", {
     className: className
   }, /*#__PURE__*/React.createElement(DynamicToolTipWrapper, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "icse-react-assets",
-  "version": "1.0.5",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "icse-react-assets",
-      "version": "1.0.5",
+      "version": "1.2.8",
       "dependencies": {
         "@carbon/icons-react": "^11.18.0",
-        "@carbon/react": "^1.36.0",
+        "@carbon/react": "^1.27.0",
         "lazy-z": "^1.10.3",
         "regex-but-with-words": "^1.5.1",
         "web-vitals": "^2.1.4"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "icse-react-assets",
   "homepage": "http://ibm.github.io/icse-react-assets",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "source": "src/index.js",

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -18,10 +18,10 @@
       }
     },
     "..": {
-      "version": "1.0.5",
+      "version": "1.2.8",
       "dependencies": {
         "@carbon/icons-react": "^11.18.0",
-        "@carbon/react": "^1.36.0",
+        "@carbon/react": "^1.27.0",
         "lazy-z": "^1.10.3",
         "regex-but-with-words": "^1.5.1",
         "web-vitals": "^2.1.4"
@@ -19171,7 +19171,7 @@
         "@babel/preset-react": "^7.18.6",
         "@babel/register": "^7.18.9",
         "@carbon/icons-react": "^11.18.0",
-        "@carbon/react": "^1.36.0",
+        "@carbon/react": "^1.27.0",
         "@rollup/plugin-babel": "^6.0.3",
         "babel-core": "^6.26.3",
         "babel-loader": "^9.1.2",

--- a/src/components/Utils.js
+++ b/src/components/Utils.js
@@ -88,7 +88,6 @@ IcseSubForm.propTypes = {
 
 export const IcseHeading = (props) => {
   let className = icseHeadingParams(props);
-  className = className.replace("marginBottomSmall", "");
   return (
     <div className={className}>
       <DynamicToolTipWrapper

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -39,10 +39,10 @@
       }
     },
     "..": {
-      "version": "1.0.5",
+      "version": "1.2.8",
       "dependencies": {
         "@carbon/icons-react": "^11.18.0",
-        "@carbon/react": "^1.36.0",
+        "@carbon/react": "^1.27.0",
         "lazy-z": "^1.10.3",
         "regex-but-with-words": "^1.5.1",
         "web-vitals": "^2.1.4"
@@ -51255,7 +51255,7 @@
         "@babel/preset-react": "^7.18.6",
         "@babel/register": "^7.18.9",
         "@carbon/icons-react": "^11.18.0",
-        "@carbon/react": "^1.36.0",
+        "@carbon/react": "^1.27.0",
         "@rollup/plugin-babel": "^6.0.3",
         "babel-core": "^6.26.3",
         "babel-loader": "^9.1.2",


### PR DESCRIPTION
Fixes the margin bottom issue, the problem was the margin bottom class was being removed completely from the heading

@Chris-Springstead I don't know what the reason was for this change originally, but if it is addressing something else lmk and we can do an alternate solution or try to add a conditional to stop it from happening

working on craig:
<img width="870" alt="Screenshot 2023-10-26 at 10 20 53 AM" src="https://github.com/IBM/icse-react-assets/assets/51029454/587b3814-33ab-443d-8d33-d324a723696d">

