### PR TITLE
Craig 987

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -11462,6 +11462,7 @@ const SshKeys = props => {
     forceOpen: props.forceOpen,
     deleteDisabled: props.deleteDisabled,
     deleteDisabledMessage: "SSH Key currently in use",
+    arrayParentName: props.powerVs ? props.arrayParentName : undefined,
     innerFormProps: {
       craig: props.craig,
       resourceGroups: props.resourceGroups,

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -11451,6 +11451,7 @@ const SshKeys = props => {
     forceOpen: props.forceOpen,
     deleteDisabled: props.deleteDisabled,
     deleteDisabledMessage: "SSH Key currently in use",
+    arrayParentName: props.powerVs ? props.arrayParentName : undefined,
     innerFormProps: {
       craig: props.craig,
       resourceGroups: props.resourceGroups,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "icse-react-assets",
   "homepage": "http://ibm.github.io/icse-react-assets",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "source": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "icse-react-assets",
   "homepage": "http://ibm.github.io/icse-react-assets",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "source": "src/index.js",

--- a/src/components/crud-form-pages/SshKeys.js
+++ b/src/components/crud-form-pages/SshKeys.js
@@ -20,6 +20,7 @@ export const SshKeys = (props) => {
       forceOpen={props.forceOpen}
       deleteDisabled={props.deleteDisabled}
       deleteDisabledMessage="SSH Key currently in use"
+      arrayParentName={props.powerVs ? props.arrayParentName : undefined}
       innerFormProps={{
         craig: props.craig,
         resourceGroups: props.resourceGroups,


### PR DESCRIPTION
arrayParentName for the ssh key was always null, so power ssh keys were always checked against regular. The logic in CRAIG differentiated keys with arrayParentName, and adding this line corrected it